### PR TITLE
Fix compiler warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule HeartCheck.Mixfile do
        extras: ["README.md", "CONTRIBUTING.md", "LICENSE.md"],
      ],
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test,
+     preferred_cli_env: [coveralls: :test, "coveralls.detail": :test,
        "coveralls.post": :test, "coveralls.html": :test],
      deps: deps()]
   end


### PR DESCRIPTION
Running with elixir 1.7.3 I an getting the following warning:
```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in
 them
  mix.exs:24
```

The solution was to remove the unneeded quotes on the keyword.