### PR TITLE
Allow plug_cowboy version 2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule HeartCheck.Mixfile do
     [
       {:jason, "~> 1.0", optional: true},
       {:plug, "~> 1.0"},
-      {:plug_cowboy, "~> 1.0", only: [:dev, :test]},
+      {:plug_cowboy, "~> 1.0 or ~> 2.0", only: [:dev, :test]},
       {:httpoison, "~> 0.10 or ~> 1.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11", only: :dev, runtime: false},
       {:earmark, "~> 1.0", only: :dev},


### PR DESCRIPTION
When trying to use heartcheck together with  phoenix 1.4 we get a dependency resolution error because phoenix 1.4 uses `plug_cowboy` version `2.0` but `heartcheck` expects version `1.0`.
```
Failed to use "plug_cowboy" (versions 2.0.0 and 2.0.1) because
  apps/api/mix.exs requires ~> 2.0
  heartcheck (version 0.4.0) requires ~> 1.0
  phoenix (version 1.4.0) requires ~> 1.0 or ~> 2.0
```