### PR TITLE
Add a docker-compose.yml configuration to make development easier.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ heartcheck-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Ignore the Mix home folder used by the Docker container.
+/.mix

--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ Returns general of the environment. OS, dependencies names and versions, elixir 
 
 ## Running tests and metrics:
 
+To easily start a docker container with the currently supported version of Elixir, you can use this command:
+
+```console
+$ docker-compose run heartcheck bash
+```
+
+To install dependencies, execute:
+
+```console
+$ mix deps.get
+```
+
 To run the tests, simply execute:
 
 ```console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  heartcheck:
+    image: elixir:1.12.3
+    volumes:
+      - .:/app
+    environment:
+      MIX_HOME: /app/.mix
+    working_dir: /app


### PR DESCRIPTION
Fixes #13 

I've added a docker-compose.yml file to the project so developpers can use the `docker-compose run heartcheck bash` command to start a shell with the correct version of Elixir. All mix commands can then be run from this shell.